### PR TITLE
for ubuntu on docker

### DIFF
--- a/ll/include/liblilfes/in.h
+++ b/ll/include/liblilfes/in.h
@@ -19,11 +19,7 @@
 #include <string>
 
 #ifndef IN_BISON_FILE
-#ifdef BISON_USE_PARSER_H_EXTENSION
-#include "yacc.h"
-#else
 #include "yacc.hh"
-#endif
 #endif
 #ifndef IN_LEX_LL
 #include "FlexLexer.h"

--- a/ll/src/Makefile.am
+++ b/ll/src/Makefile.am
@@ -76,11 +76,6 @@ AM_LFLAGS = -8
 DEFS= @DEFS@ -DPKGDATADIR="\"$(pkgdatadir)\""
 #INCLUDES= -I$(srcdir)
 
-if BISON_USE_PARSER_H
-yacc.hh: yacc.h
-	cp $< $@
-endif
-
 doc :
 	@PERL@ ../lildoc.prl -e -s -b . -t "Builtin" -o ../manual -c style-builtin.css -f builtin- . builtin-index.html
 jdoc :


### PR DESCRIPTION
docker上のubuntuでうまく動かなかったため、BISONのyacc.hを強制的にyacc.hhを使うように変更。